### PR TITLE
Add support for `std::thread` in the toolchain

### DIFF
--- a/gcc/config/mips/psp.h
+++ b/gcc/config/mips/psp.h
@@ -23,11 +23,13 @@ Boston, MA 02111-1307, USA.  */
 #define LIB_SPEC " \
     -lm \
     --start-group \
+    -lpthreadglue \
+    -lpthread \
     -lcglue \
     %{g:-lg} %{!g:-lc} \
     --end-group \
     -lpsputility -lpsprtc -lpspnet_inet -lpspnet_resolver \
-    -lpspmodinfo -lpspuser -lpspkernel"
+    -lpspsdk -lpspmodinfo -lpspuser -lpspkernel"
 
 /* Override the startfile spec to include crt0.o. */
 #undef STARTFILE_SPEC

--- a/libgcc/gthr.h
+++ b/libgcc/gthr.h
@@ -144,6 +144,17 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #ifndef GTHREAD_USE_WEAK
 #define GTHREAD_USE_WEAK 1
 #endif
+
+/* *** PSP Specific change for std::thread ***
+   This file is modified by running sed commands on the 
+   libstdc++-v3/include/Makefile.am
+   These sed commands add prefix to the existing macros
+   this is why we CAN'T add here an #if __PSP__
+   As solution we force here GTHREAD_USE_WEAK to be 0 
+*/
+#undef GTHREAD_USE_WEAK
+#define GTHREAD_USE_WEAK 0
+
 #endif
 #include "gthr-default.h"
 


### PR DESCRIPTION
## DESCRIPTION

This PR is part of a collection for the `std::tread` support in the `PSP Toolchain`

It basically does:
- Add `libpthread.a`, libpthreadglue.a` and ,libpspsdk.a` as part of the standard libraries
- GCC looks to have a bug with `GTHREAD_USE_WEAK` so we are forcing to be disabled.