### PR TITLE
Fix direct no-target builtins with no operands.

### DIFF
--- a/gcc/config/mips/mips.c
+++ b/gcc/config/mips/mips.c
@@ -15396,7 +15396,7 @@ AVAIL_NON_MIPS16 (msa, TARGET_MSA)
    builtin_description fields.  */
 #define DIRECT_ALLEGREX_NO_TARGET_BUILTIN(INSN, FUNCTION_TYPE, TARGET_FLAGS)   \
   { CODE_FOR_allegrex_ ## INSN, MIPS_FP_COND_f, "__builtin_allegrex_" #INSN,            \
-    MIPS_BUILTIN_DIRECT_NO_TARGET, FUNCTION_TYPE, mips_builtin_avail_allegrex }
+    MIPS_BUILTIN_DIRECT_NO_TARGET, FUNCTION_TYPE, mips_builtin_avail_allegrex, false }
 
 /* Define a builtin with a specific function TYPE.  */
 #define SPECIAL_ALLEGREX_BUILTIN(TYPE, INSN, FUNCTION_TYPE, TARGET_FLAGS)  \

--- a/gcc/optabs.c
+++ b/gcc/optabs.c
@@ -7779,6 +7779,8 @@ maybe_gen_insn (enum insn_code icode, unsigned int nops,
 
   switch (nops)
     {
+    case 0:
+      return GEN_FCN (icode) ();
     case 1:
       return GEN_FCN (icode) (ops[0].value);
     case 2:


### PR DESCRIPTION
Seems a bit odd that no other instruction triggers this corner case.
After some reading in the gcc code I can be somehow confident this might be the "right fix". There's only x86 doing no-return no-args opcodes (with builtins) and they follow a more direct path to code emission. For some reason mips goes through maybe_expand_insn, for simplicity I suppose.
Perhaps a cleaner solution would be to handle the case in mips_expand_builtin_insn like ix86_expand_special_args_builtin does for VOID_FTYPE_VOID. But not sure if that's even more confusing.
Anyway here we go! This is for https://github.com/pspdev/psptoolchain/issues/98