### PR TITLE
Disable use of GP-relative addressing

### DIFF
--- a/config/mt-allegrex-psp
+++ b/config/mt-allegrex-psp
@@ -1,0 +1,3 @@
+# Disable use of GP-relative addressing
+CFLAGS_FOR_TARGET += -mno-gpopt
+CXXFLAGS_FOR_TARGET += -mno-gpopt

--- a/configure
+++ b/configure
@@ -9578,6 +9578,9 @@ case "${target}" in
     extra_arflags_for_target=" -X32_64"
     extra_nmflags_for_target=" -B -X32_64"
     ;;
+  mipsallegrex*-psp-elf*)
+    target_makefile_frag="config/mt-allegrex-psp"
+    ;;
 esac
 
 alphaieee_frag=/dev/null

--- a/configure.ac
+++ b/configure.ac
@@ -2739,6 +2739,9 @@ case "${target}" in
     extra_arflags_for_target=" -X32_64"
     extra_nmflags_for_target=" -B -X32_64"
     ;;
+  mipsallegrex*-psp-elf*)
+    target_makefile_frag="config/mt-allegrex-psp"
+    ;;
 esac
 
 alphaieee_frag=/dev/null

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -2719,9 +2719,9 @@ mipstx39-*-elf* | mipstx39el-*-elf*)
 	;;
 mipsallegrex-*-elf* | mipsallegrexel-*-elf*)
 	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/elf.h"
-	tmake_file="mips/t-elf"
+	tmake_file="${tmake_file} mips/t-elf"
 	target_cpu_default="MASK_SINGLE_FLOAT|MASK_DIVIDE_BREAKS"
-	tm_defines="MIPS_ISA_DEFAULT=2 MIPS_CPU_STRING_DEFAULT=\\\"allegrex\\\" MIPS_ABI_DEFAULT=ABI_EABI"
+	tm_defines="${tm_defines} MIPS_ISA_DEFAULT=2 MIPS_CPU_STRING_DEFAULT=\\\"allegrex\\\" MIPS_ABI_DEFAULT=ABI_EABI"
 	case ${target} in
 	mipsallegrex*-psp-elf*)
 		tm_file="${tm_file} mips/psp.h"

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -1087,10 +1087,8 @@ mips-wrs-vxworks)
 mipstx39-*-elf* | mipstx39el-*-elf*)
 	tmake_file="$tmake_file mips/t-crtstuff mips/t-mips16"
 	;;
-mips*-psp*)
-	tmake_file="${tmake_file} mips/t-elf mips/t-crtstuff"
-	target_cpu_default="MASK_SINGLE_FLOAT|MASK_DIVIDE_BREAKS"
-	tm_file="${tm_file}"
+mipsallegrex*-psp*)
+	tmake_file="$tmake_file mips/t-allegrex-psp"
 	extra_parts="$extra_parts crti.o crtn.o"
 	;;
 mmix-knuth-mmixware)

--- a/libgcc/config/mips/t-allegrex-psp
+++ b/libgcc/config/mips/t-allegrex-psp
@@ -1,0 +1,2 @@
+# Disable use of GP-relative addressing in startup code.
+CRTSTUFF_T_CFLAGS += -mno-gpopt


### PR DESCRIPTION
1. **Disable use of GP-relative addressing** 
Ref #5

2. ~~**Use int, instead of long int, for int32_t and uint32_t.**~~
