### PR TITLE
Adding libpspprof as part of standards when using -pg flag

### DIFF
--- a/gcc/config/mips/psp.h
+++ b/gcc/config/mips/psp.h
@@ -27,6 +27,7 @@ Boston, MA 02111-1307, USA.  */
     -lpthread \
     -lcglue \
     %{g:-lg} %{!g:-lc} \
+    %{pg:-lpspprof} \
     --end-group \
     -lpsputility -lpsprtc -lpspnet_inet -lpspnet_resolver \
     -lpspsdk -lpspmodinfo -lpspuser -lpspkernel"


### PR DESCRIPTION
## Description
This PRs makes more standard the usage of `-pg` flag when running homebrew for checking where are the most important bottlenecks.